### PR TITLE
chore(dependabot): rewrite groups, update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,23 +8,21 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps/npm):"
     labels:
       - "t-dependencies"
       - "pkg-npm"
     groups:
-      typescript-eslint:
+      typescript:
         patterns:
-          - "@typescript-eslint/*"
-          - "eslint*"
           - "typescript"
           - "typedoc"
-      markdownlint:
+      lint:
         patterns:
-          - "markdownlint-cli2"
-          - "markdownlint-config-neoncitylights"
+          - "eslint*"
+          - "markdownlint*"
       vite:
         patterns:
           - "vite"
@@ -36,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
     commit-message:
       prefix: "chore(deps/actions):"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
-          - "eslint"
+          - "eslint*"
           - "typescript"
           - "typedoc"
       markdownlint:


### PR DESCRIPTION
- the pattern for `@typescript-eslint` is removed since its already installed indirectly through `eslint-config-neoncitylights`
- create `typescript` group to replace `typescript-eslint`
- create `lint` group to replace `typescript-eslint` and `markdownlint`
- check npm ecosystem weekly (updates somewhat frequently!)
- check actions ecosystem daily (doesn't update often but is good to have updates immediately)