### PR TITLE
ci: cleanup main CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm run build
 
   lint:
-    name: lint (${{ matrix.tool-lc }})
+    name: lint (${{ matrix.tool }})
     runs-on: ubuntu-latest
     needs: build
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: build (Node v@${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,7 +27,6 @@ jobs:
       - name: Build packages
         run: npm run build
 
-
   lint:
     name: lint (${{ matrix.tool-lc }})
     runs-on: ubuntu-latest
@@ -34,22 +34,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - tool-lc: eslint
-            tool-uc: ESLint
+          - tool: ESLint
             npm-cmd-suffix: es
-            env-cmd: |
+            npm-cmd-env: |
               npm run lint:es-env
-          - tool-lc: markdownlint
-            tool-uc: Markdownlint
+          - tool: Markdownlint
             npm-cmd-suffix: md
-            env-cmd: |
+            npm-cmd-env: |
               node --version
               npm --version
               npm run lint:md-env
-          - tool-lc: publint
-            tool-uc: publint
+          - tool: publint
             npm-cmd-suffix: pub
-            env-cmd: |
+            npm-cmd-env: |
               node --version
               npm --version
               npm run lint:pub-env
@@ -65,8 +62,8 @@ jobs:
         run: npm ci
       - name: Print environment info
         run: |
-          ${{ matrix.env-cmd }}
-      - name: Lint with ${{ matrix.tool-uc }}
+          ${{ matrix.npm-cmd-env }}
+      - name: Lint with ${{ matrix.tool }}
         run: npm run lint:${{ matrix.npm-cmd-suffix }}
 
   test:
@@ -113,7 +110,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  is-publishable:
+  pkg-dry-run:
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -134,25 +131,13 @@ jobs:
 
   ci-success:
     runs-on: ubuntu-latest
-    if: ${{ success() && github.event_name == 'push' }}
+    if: ${{ success() }}
     needs:
       - build
       - lint
       - test
       - docs
-      - is-publishable
-    steps:
-      - name: ✅ CI succeeded
-        run: exit 0
-
-  ci-success-pr:
-    runs-on: ubuntu-latest
-    if: ${{ success() && github.event_name == 'pull_request' }}
-    needs:
-      - build
-      - lint
-      - test
-      - is-publishable
+      - pkg-dry-run
     steps:
       - name: ✅ CI succeeded
         run: exit 0


### PR DESCRIPTION
 - mention Node version name for build job
 - make parameter names in lint job matrix more consistent
 - simplify "is-publishable" job name to "pkg-dry-run"
 - remove ci-success-pr job, simplify to just ci-success job