### PR TITLE
chore: more cleanup for ESM + Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,19 +17,17 @@
 		"url": "https://github.com/sponsors/{{author}}"
 	},
 	"type": "module",
-	"module": "./dist/{{package}}.es.js",
+	"types": "./dist/index.d.ts",
+	"module": "./dist/{{package}}.mjs",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"import": "./dist/{{package}}.es.js"
+			"import": "./dist/{{package}}.mjs"
 		}
 	},
 	"files": [
 		"dist"
 	],
-	"directories": {
-		"test": "tests"
-	},
 	"scripts": {
 		"build": "vite build",
 		"build:typedoc": "npx typedoc",
@@ -43,7 +41,7 @@
 		"test:ui": "npm run test -- --ui",
 		"test:watch": "npm run test -- --watch",
 		"test:all": "npm run test:ci && npm run lint",
-		"lint": "npm run lint:md && npm run lint:es",
+		"lint": "npm run lint:md && npm run lint:es && npm run lint:pub",
 		"lint:fix": "npm run lint:md-fix && npm run lint:es-fix",
 		"lint:md": "markdownlint-cli2 \"*/**.md\" \"#node_modules\"",
 		"lint:md-fix": "npm run lint:md -- --fix",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
-import path from 'path';
+import path from 'node:path';
+
 import dts from 'vite-plugin-dts';
 import { defineConfig } from 'vitest/config';
 
@@ -6,9 +7,8 @@ export default defineConfig({
 	build: {
 		lib: {
 			entry: path.resolve(__dirname, 'src/index.ts'),
-			name: '{{package}}',
 			formats: ['es'],
-			fileName: (format) => `{{package}}.${format}.js`,
+			fileName: () => '{{package}}.mjs',
 		},
 	},
 	define: { 


### PR DESCRIPTION
vite.config.ts:
- don't use build.lib.name, only needed for umd/iife packages
- simplify build.lib.fileName
- use ESM node module for `path` via `node:path`

package.json:
- register types at root too, not just exports
- also run publint when running `npm run lint`
- remove `directories` key, not needed (defined from CommonJS spec)