### PR TITLE
docs: add link to `vitest.workspace.ts`, update other links

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,15 @@ These are the most relevant commands that you'll likely use:
 
 | Tool | File | Documentation |
 | ---- | ---- | ------------- |
-| NPM package | [`package.json`](packages/pkg1/package.json) | [docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json), [website](https://docs.npmjs.com/) |
+| NPM package | [`package.json`](packages/pkg1/package.json) | [docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json), [website](https://docs.npmjs.com/) |
 | TypeScript | [`tsconfig.json`](packages/pkg1/tsconfig.json) | [docs](https://www.typescriptlang.org/tsconfig), [website](https://www.typescriptlang.org/) |
 | TypeDoc (documentation generator) | [`tsconfig.json`](packages/pkg1/tsconfig.json) (`typedocOptions`) | [docs](https://typedoc.org/options/configuration/), [website](https://typedoc.org/) |
-| ESLint (code formatter + linter) | [`eslint.config.js`](./eslint.config.js) | [docs](https://eslint.org/docs/latest/user-guide/configuring/), [website](https://eslint.org/) |
+| ESLint (code formatter + linter) | [`eslint.config.js`](./eslint.config.js) | [docs](https://eslint.org/docs/latest/use/configure/), [website](https://eslint.org/) |
 | Markdownlint (Markdown linter)   | [`.markdownlint-cli2.jsonc`](./.markdownlint-cli2.jsonc) | [docs](https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2jsonc) |
 | Vite (bundler) | [`vite.config.ts`](packages/pkg1/vite.config.ts) | [docs](https://vitejs.dev/config/), [website](https://vitejs.dev/) |
 | Vitest (testing framework) | [`vite.config.ts`](packages/pkg1/vite.config.ts) (`test`) | [docs](https://vitest.dev/config/), [website](https://vitest.dev/) |
-| CodeSandbox CI | [`.codesandbox/ci.json`](./.codesandbox/ci.json) | [docs](https://codesandbox.io/docs/learn/sandboxes/ci#configuration), [website](https://codesandbox.io/) |
+| Vitest workspace | [`vitest.workspace.ts`](./vitest.workspace.ts) | [docs](https://vitest.dev/guide/workspace.html#workspace) |
+| CodeSandbox CI | [`.codesandbox/ci.json`](./.codesandbox/ci.json) | [docs](https://codesandbox.io/docs/learn/ci#configuration), [website](https://codesandbox.io/) |
 | Dependabot | [`.github/dependabot.yml`](./.github/dependabot.yml) | [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file), [website](https://github.com/dependabot) |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ These are the most relevant commands that you'll likely use:
 
 ## License
 
-This software is licensed under the MIT license ([`LICENSE-MIT`](./LICENSE) or <http://opensource.org/licenses/MIT>).
+This software is licensed under the MIT license ([`LICENSE-MIT`](./LICENSE) or <https://opensource.org/license/mit/>).
 
 ### Contribution
 


### PR DESCRIPTION
- Fixe 404 link to CodeSandbox CI
- Update ESLint configuration from redirect link to canonical link
- Update link regarding NPM's package.json file to latest version (v9 to v10)
- Change HTTP to HTTPS for MIT license link