### PR TITLE
ci: only run CodeQL workflow on schedule

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,11 +12,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
     # Run once a week on Monday at 00:00 (12:00AM or Midnight, UTC)
     # See POSIX cron syntax visualized at https://crontab.guru/#0_0_*_*_1


### PR DESCRIPTION
The workflow runs a bit slow, and one official suggestion is to switch to only run during schedule events: https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/analysis-takes-too-long#run-only-during-a-schedule-event