### PR TITLE
tests: minor cleanup to vitest coverage setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ npm publish --access public
 
 | Tool               | File | Documentation |
 | ------------------ | ---- | ------------- |
-| NPM                | [`package.json`](package.json) | [docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json), [website](https://docs.npmjs.com/) |
+| NPM                | [`package.json`](package.json), [`packages/*/package.json`](./packages/pkg1/package.json) | [docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json), [website](https://docs.npmjs.com/) |
 | TypeScript         | [`tsconfig.json`](./tsconfig.json), [`packages/*/tsconfig.json`](packages/pkg1/tsconfig.json) | [docs](https://www.typescriptlang.org/tsconfig), [website](https://www.typescriptlang.org/) |
 | TypeDoc            | [`tsconfig.json`](tsconfig.json) (`typedocOptions`) | [docs](https://typedoc.org/options/configuration/), [website](https://typedoc.org/) |
 | ESLint             | [`eslint.config.js`](./eslint.config.js) | [docs](https://eslint.org/docs/latest/use/configure/), [website](https://eslint.org/) |
 | Vite               | [`packages/*/vite.config.ts`](packages/pkg1/vite.config.ts) | [docs](https://vitejs.dev/config/), [website](https://vitejs.dev/) |
-| Vitest             | [`packages/*/vite.config.ts`](packages/pkg1/vite.config.ts) (`test`) | [docs](https://vitest.dev/config/), [website](https://vitest.dev/) |
+| Vitest             | [`vitest.config.ts`](./vitest.config.ts), [`packages/*/vite.config.ts`](packages/pkg1/vite.config.ts) (`test`) | [docs](https://vitest.dev/config/), [website](https://vitest.dev/) |
 | Vitest (workspace) | [`vitest.workspace.ts`](./vitest.workspace.ts) | [docs](https://vitest.dev/guide/workspace.html) |
 | Dependabot         | [`.github/dependabot.yml`](./.github/dependabot.yml) | [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file), [website](https://github.com/dependabot) |
 

--- a/packages/pkg1/vite.config.ts
+++ b/packages/pkg1/vite.config.ts
@@ -19,10 +19,5 @@ export default defineProject({
 	],
 	test: {
 		includeSource: ['src/**/*.{js,ts}'],
-		coverage: {
-			include: ['src/**/*.{js,ts}'],
-			provider: 'v8',
-			reporter: ['text', 'json', 'html'],
-		},
 	},
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		coverage: {
+			include: ['packages/**/src'],
+			provider: 'v8',
+		},
+	},
+})


### PR DESCRIPTION
This fixes a small regression, and re-shrinks down the included code coverage in the workspace. 
- See https://github.com/vitest-dev/vitest/discussions/3852, which recommends including a `./vitest.config.ts` alongside `./vitest.workspace.ts`.
- Workspace projects do not support setting `coverage`, hence set in the root `./vitest.config.ts` file.
- (Unrelated) This resets Codecov setup by setting CODECOV_TOKEN in GitHub Actions secret for this repository locally.